### PR TITLE
iOS support

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -26,6 +26,10 @@ jobs:
           os: ubuntu-latest
           target: Android64
 
+        - name: iOS
+          os: macos-latest
+          target: iOS
+
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
 
@@ -37,7 +41,7 @@ jobs:
         with:
           combine: true
           target: ${{ matrix.config.target }}
-          bindings: 'weebifying/bindings'
+          bindings: 'geode-sdk/bindings'
           sdk: 'nightly'
           build-config: RelWithDebInfo
           export-pdb: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.21)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "iOS" OR IOS)
+    set(CMAKE_OSX_ARCHITECTURES "arm64")
+else()
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+endif()
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 project(CoinsinPauseMenu VERSION 1.2.0)

--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "4.0.0-beta.1",
+	"geode": "4.4.0",
 	"gd": {
 		"win": "2.2074",
 		"android": "2.2074",
@@ -19,11 +19,7 @@
 			"resources/ss.png"
 		]
 	},
-	"dependencies": [
-		{
-			"id": "geode.node-ids",
-			"version": ">=1.17.0",
-			"importance": "required"
-		}
-	]
+	"dependencies": {
+		"geode.node-ids": ">=1.17.0"
+	}
 }

--- a/mod.json
+++ b/mod.json
@@ -3,7 +3,8 @@
 	"gd": {
 		"win": "2.2074",
 		"android": "2.2074",
-		"mac": "2.2074"
+		"mac": "2.2074",
+		"iOS": "2.2074"
 	},
 	"version": "v1.2.0",
 	"id": "weebify.coins_in_pause_menu",

--- a/mod.json
+++ b/mod.json
@@ -4,7 +4,7 @@
 		"win": "2.2074",
 		"android": "2.2074",
 		"mac": "2.2074",
-		"iOS": "2.2074"
+		"ios": "2.2074"
 	},
 	"version": "v1.2.0",
 	"id": "weebify.coins_in_pause_menu",


### PR DESCRIPTION
iOS support, dependency syntax changed, and bindings from geode-sdk/bindings

The code excluded from android seems to work perfectly on iOS with some testing, but up to you if you'd like to change that to GEODE_IS_MOBILE